### PR TITLE
Change the API of the optimizer

### DIFF
--- a/doc/periodic/supersmoother.rst
+++ b/doc/periodic/supersmoother.rst
@@ -1,5 +1,8 @@
 .. _periodic_supersmoother
 
+SuperSmoother
+=============
+
 .. currentmodule:: gatspy.periodic
 
 .. testsetup:: *
@@ -7,8 +10,6 @@
     from gatspy import datasets, periodic
     from gatspy.periodic import *
 
-SuperSmoother
-=============
 The supersmoother is a non-parametric adaptive smoother which has been used
 within the astronomical literature as an estimator of periodic content. For
 each candidate frequency, the supersmoother algorithm is applied to the phased
@@ -31,10 +32,9 @@ of this example:
     >>> t, mag, dmag, filts = rrlyrae.get_lightcurve(lcid)
     >>> mask = (filts == 'r')
     >>> t_r, mag_r, dmag_r = t[mask], mag[mask], dmag[mask]
-    >>> model = periodic.SuperSmoother()
+    >>> model = periodic.SuperSmoother(fit_period=True)
     >>> model.optimizer.period_range = (0.61, 0.62)
     >>> model = model.fit(t_r, mag_r, dmag_r)
-    >>> period = model.best_period
     Finding optimal frequency:
      - Estimated peak width = 0.00189
      - Using 5 steps per peak; omega_step = 0.000378
@@ -42,7 +42,7 @@ of this example:
      - Computing periods at 441 steps
     Zooming-in on 5 candidate peaks:
      - Computing periods at 995 steps
-    >>> print("{0:.6f}".format(period))
+    >>> print("{0:.6f}".format(model.best_period))
     0.614320
 
 Let's take a look at the best-fit supersmoother model at this period:

--- a/gatspy/periodic/lomb_scargle.py
+++ b/gatspy/periodic/lomb_scargle.py
@@ -118,6 +118,10 @@ class LombScargle(LeastSquaresMixin, PeriodicModeler):
         least squares fit.
     regularize_by_trace : boolean (default = True)
         If True, multiply regularization by the trace of the matrix
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
 
     Examples
     --------
@@ -127,6 +131,7 @@ class LombScargle(LeastSquaresMixin, PeriodicModeler):
     >>> omega = 10
     >>> y = np.sin(omega * t) + dy * rng.randn(100)
     >>> ls = LombScargle().fit(t, y, dy)
+    >>> ls.optimizer.period_range = (0.2, 1.2)
     >>> ls.best_period
     Finding optimal frequency:
      - Estimated peak width = 0.0639
@@ -146,13 +151,15 @@ class LombScargle(LeastSquaresMixin, PeriodicModeler):
     LombScargleMultibandFast
     """
     def __init__(self, optimizer=None, center_data=True, fit_offset=True,
-                 Nterms=1, regularization=None, regularize_by_trace=True):
+                 Nterms=1, regularization=None, regularize_by_trace=True,
+                 fit_period=False, optimizer_kwds=None):
         self.center_data = center_data
         self.fit_offset = fit_offset
         self.Nterms = int(Nterms)
         self.regularization = regularization
         self.regularize_by_trace = regularize_by_trace
-        PeriodicModeler.__init__(self, optimizer)
+        PeriodicModeler.__init__(self, optimizer, fit_period=fit_period,
+                                 optimizer_kwds=optimizer_kwds)
 
         if not self.center_data and not self.fit_offset:
             warnings.warn("Not centering data or fitting offset can lead "
@@ -223,6 +230,10 @@ class LombScargleAstroML(LombScargle):
     slow_version : boolean (default = False)
         If True, use the slower pure-python version from astroML. Otherwise,
         use the faster version of the code from astroML_addons
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
 
     Examples
     --------
@@ -232,6 +243,7 @@ class LombScargleAstroML(LombScargle):
     >>> omega = 10
     >>> y = np.sin(omega * t) + dy * rng.randn(100)
     >>> ls = LombScargleAstroML().fit(t, y, dy)
+    >>> ls.optimizer.period_range = (0.2, 1.2)
     >>> ls.best_period
     Finding optimal frequency:
      - Estimated peak width = 0.0639
@@ -249,12 +261,15 @@ class LombScargleAstroML(LombScargle):
     LombScargleMultibandFast
     """
     def __init__(self, optimizer=None, Nterms=1, fit_offset=True,
-                 center_data=True, slow_version=False):
+                 center_data=True, slow_version=False,
+                 fit_period=False, optimizer_kwds=None):
         if Nterms != 1:
             raise ValueError("Only Nterms=1 is supported")
 
         LombScargle.__init__(self, optimizer=optimizer, Nterms=1,
-                             center_data=center_data, fit_offset=fit_offset)
+                             center_data=center_data, fit_offset=fit_offset,
+                             fit_period=fit_period,
+                             optimizer_kwds=optimizer_kwds)
         if slow_version:
             from astroML.time_series._periodogram import lomb_scargle
         else:

--- a/gatspy/periodic/lomb_scargle_fast.py
+++ b/gatspy/periodic/lomb_scargle_fast.py
@@ -347,6 +347,10 @@ class LombScargleFast(LombScargle):
         the result
     ls_kwds : dict
         Dictionary of keywords to pass to the ``lomb_scargle_fast`` routine.
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
 
     Examples
     --------
@@ -356,6 +360,7 @@ class LombScargleFast(LombScargle):
     >>> omega = 10
     >>> y = np.sin(omega * t) + dy * rng.randn(100)
     >>> ls = LombScargleFast().fit(t, y, dy)
+    >>> ls.optimizer.period_range = (0.2, 1.2)
     >>> ls.best_period
     Finding optimal frequency:
      - Estimated peak width = 0.0639
@@ -379,7 +384,8 @@ class LombScargleFast(LombScargle):
            of unevenly sampled data". ApJ 1:338, p277, 1989
     """
     def __init__(self, optimizer=None, center_data=True, fit_offset=True,
-                 use_fft=True, ls_kwds=None, Nterms=1):
+                 use_fft=True, ls_kwds=None, Nterms=1,
+                 fit_period=False, optimizer_kwds=None):
         self.use_fft = use_fft
         self.ls_kwds = ls_kwds
 
@@ -388,7 +394,9 @@ class LombScargleFast(LombScargle):
 
         LombScargle.__init__(self, optimizer=optimizer,
                              center_data=center_data, fit_offset=fit_offset,
-                             Nterms=1, regularization=None)
+                             Nterms=1, regularization=None,
+                             fit_period=fit_period,
+                             optimizer_kwds=optimizer_kwds)
 
     def _score_frequency_grid(self, f0, df, N):
         freq, P = lomb_scargle_fast(self.t, self.y, self.dy,

--- a/gatspy/periodic/lomb_scargle_multiband.py
+++ b/gatspy/periodic/lomb_scargle_multiband.py
@@ -47,14 +47,16 @@ class LombScargleMultiband(LeastSquaresMixin, PeriodicModelerMultiband):
     """
     def __init__(self, optimizer=None, Nterms_base=1, Nterms_band=1,
                  reg_base=None, reg_band=1E-6, regularize_by_trace=True,
-                 center_data=True):
+                 center_data=True, fit_period=False, optimizer_kwds=None):
         self.Nterms_base = Nterms_base
         self.Nterms_band = Nterms_band
         self.reg_base = reg_base
         self.reg_band = reg_band
         self.regularize_by_trace = regularize_by_trace
         self.center_data = center_data
-        PeriodicModelerMultiband.__init__(self, optimizer)
+        PeriodicModelerMultiband.__init__(self, optimizer,
+                                          fit_period=fit_period,
+                                          optimizer_kwds=optimizer_kwds)
 
     def _fit(self, t, y, dy, filts):
         self.ymean_ = self._compute_ymean()
@@ -162,6 +164,10 @@ class LombScargleMultibandFast(PeriodicModelerMultiband):
         The base model to use for each individual band.
         By default it will use :class:`LombScargleFast` if Nterms == 1, and
         :class:`LombScargle` otherwise.
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
 
     See Also
     --------
@@ -169,7 +175,8 @@ class LombScargleMultibandFast(PeriodicModelerMultiband):
     LombScargleFast
     LombScargleMultiband
     """
-    def __init__(self, optimizer=None, Nterms=1, BaseModel=None):
+    def __init__(self, optimizer=None, Nterms=1, BaseModel=None,
+                 fit_period=False, optimizer_kwds=None):
         # Note: center_data must be True, or else the chi^2 weighting will fail
         self.Nterms = Nterms
 
@@ -179,7 +186,9 @@ class LombScargleMultibandFast(PeriodicModelerMultiband):
             else:
                 BaseModel = LombScargle
         self.BaseModel = BaseModel
-        PeriodicModelerMultiband.__init__(self, optimizer)
+        PeriodicModelerMultiband.__init__(self, optimizer,
+                                          fit_period=fit_period,
+                                          optimizer_kwds=optimizer_kwds)
 
     def _fit(self, t, y, dy, filts):
         masks = [(filts == f) for f in self.unique_filts_]

--- a/gatspy/periodic/naive_multiband.py
+++ b/gatspy/periodic/naive_multiband.py
@@ -29,17 +29,27 @@ class NaiveMultiband(PeriodicModelerMultiband):
 
     Parameters
     ----------
+    optimizer : PeriodicOptimizer instance
+        Optimizer to use to find the best period. If not specified, the
+        LinearScanOptimizer will be used.
     BaseModel : PeriodicModeler instance
         Single-band model to use on data from each band.
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
     *args, **kwargs :
         additional arguments are passed to BaseModel on construction.
     """
     def __init__(self, optimizer=None, BaseModel=LombScargle,
+                 fit_period=False, optimizer_kwds=None,
                  *args, **kwargs):
         self.BaseModel = BaseModel
         self.args = args
         self.kwargs = kwargs
-        PeriodicModelerMultiband.__init__(self, optimizer)
+        PeriodicModelerMultiband.__init__(self, optimizer,
+                                          fit_period=fit_period,
+                                          optimizer_kwds=optimizer_kwds)
 
     def _fit(self, t, y, dy, filts):
         t, y, dy, filts = np.broadcast_arrays(t, y, dy, filts)

--- a/gatspy/periodic/supersmoother.py
+++ b/gatspy/periodic/supersmoother.py
@@ -24,6 +24,10 @@ class SuperSmoother(PeriodicModeler):
     optimizer : PeriodicOptimizer instance
         Optimizer to use to find the best period. If not specified, the
         LinearScanOptimizer will be used.
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
 
     Examples
     --------
@@ -33,6 +37,7 @@ class SuperSmoother(PeriodicModeler):
     >>> omega = 10
     >>> y = np.sin(omega * t) + dy * rng.randn(100)
     >>> ssm = SuperSmoother().fit(t, y, dy)
+    >>> ssm.optimizer.period_range = (0.2, 1.2)
     >>> ssm.best_period
     Finding optimal frequency:
      - Estimated peak width = 0.0639
@@ -49,8 +54,11 @@ class SuperSmoother(PeriodicModeler):
     --------
     LombScargle
     """
-    def __init__(self, optimizer=None):
-        PeriodicModeler.__init__(self, optimizer)
+    def __init__(self, optimizer=None,
+                 fit_period=False, optimizer_kwds=None):
+        PeriodicModeler.__init__(self, optimizer,
+                                 fit_period=fit_period,
+                                 optimizer_kwds=optimizer_kwds)
 
     def _fit(self, t, y, dy):
         # TODO: this should actually be a weighted median, probably...
@@ -80,10 +88,17 @@ class SuperSmootherMultiband(PeriodicModelerMultiband):
         LinearScanOptimizer will be used.
     BaseModel : class type (default = SuperSmoother)
         The base model to use for each individual band.
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional
+        Dictionary of keyword arguments for constructing the optimizer
     """
-    def __init__(self, optimizer=None, BaseModel=SuperSmoother):
+    def __init__(self, optimizer=None, BaseModel=SuperSmoother,
+                 fit_period=False, optimizer_kwds=None):
         self.BaseModel = BaseModel
-        PeriodicModelerMultiband.__init__(self, optimizer)
+        PeriodicModelerMultiband.__init__(self, optimizer,
+                                          fit_period=fit_period,
+                                          optimizer_kwds=optimizer_kwds)
 
     def _fit(self, t, y, dy, filts):
         masks = [(filts == f) for f in self.unique_filts_]

--- a/gatspy/periodic/tests/test_lomb_scargle.py
+++ b/gatspy/periodic/tests/test_lomb_scargle.py
@@ -136,6 +136,7 @@ def test_regularized(N=100, period=1):
         model = LombScargle(Nterms=1, regularization=0.1,
                             regularize_by_trace=regularize_by_trace)
         model.fit(t, y, dy)
+        model.optimizer.period_range = (0.2, 1.0)
         pred = model.predict(period)
 
 

--- a/gatspy/periodic/tests/test_lomb_scargle_fast.py
+++ b/gatspy/periodic/tests/test_lomb_scargle_fast.py
@@ -114,6 +114,8 @@ def test_find_best_period():
         fast = LombScargleFast(fit_offset=fit_offset,
                                center_data=center_data,
                                use_fft=use_fft).fit(t, y, dy)
+        model.optimizer.period_range = (0.2, 1.0)
+        fast.optimizer.period_range = (0.2, 1.0)
         assert_allclose(model.best_period, fast.best_period, atol=5E-4)
 
     for use_fft in [True, False]:


### PR DESCRIPTION
This PR changes the basic API of the period optimizer

- remove the default ``period_range``: this really should be set by the user, and setting it quietly will cause problems more often than not
- add a ``fit_period`` option which will do the period fit when the ``fit()`` method is called.
- update documentation and tests to account for this.