### PR TITLE
Fix ImportError when gatspy is installed as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ def read(path, encoding='utf-8'):
 
 
 def version(path):
+    """Obtain the packge version from a python file e.g. pkg/__init__.py
+
+    See <https://packaging.python.org/en/latest/single_source_version.html>.
+    """
     version_file = read(path)
     version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
                               version_file, re.M)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,24 @@
+import io
+import os
+import re
+
 from distutils.core import setup
+
+
+def read(path, encoding='utf-8'):
+    path = os.path.join(os.path.dirname(__file__), path)
+    with io.open(path, encoding=encoding) as fp:
+        return fp.read()
+
+
+def version(path):
+    version_file = read(path)
+    version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 DESCRIPTION = "General tools for Astronomical Time Series in Python"
 LONG_DESCRIPTION = """
@@ -18,8 +38,7 @@ URL = 'http://github.com/astroml/gatspy'
 DOWNLOAD_URL = 'http://github.com/astroml/gatspy'
 LICENSE = 'BSD 3-clause'
 
-import gatspy
-VERSION = gatspy.__version__
+VERSION = version('gatspy/__init__.py')
 
 setup(name=NAME,
       version=VERSION,


### PR DESCRIPTION
When other packages install gatspy as one of their dependencies it's not safe to import gatspy during the install phase.
This is because gatspy's own dependencies might not be installed yet, e.g. astroML.

This change will fix the following error:

    $ pip install .[full]
    Processing /home/alex/src/pandashells
    Requirement already satisfied (use --upgrade to upgrade): numpy in ./lib/python2.7/site-packages (from pandashells==0.1.4)
    Collecting pandas (from pandashells==0.1.4)
      Downloading pandas-0.16.2.tar.gz (4.9MB)
        100% |████████████████████████████████| 4.9MB 122kB/s
    ...
    Collecting gatspy (from pandashells==0.1.4)
      Downloading gatspy-0.2.tar.gz
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 20, in <module>
          File "/tmp/pip-build-0s5QDI/gatspy/setup.py", line 21, in <module>
            import gatspy
          File "gatspy/__init__.py", line 7, in <module>
            from . import datasets, periodic
          File "gatspy/datasets/__init__.py", line 13, in <module>
            from .rrlyrae import *
          File "gatspy/datasets/rrlyrae.py", line 15, in <module>
            from astroML.datasets.tools import get_data_home, download_with_progress_bar
        ImportError: No module named astroML.datasets.tools

        ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-0s5QDI/gatspy