### PR TITLE
Baluev method plus an notebook example

### DIFF
--- a/examples/baluev_method_for_false_alarm_probability.ipynb
+++ b/examples/baluev_method_for_false_alarm_probability.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Baluev Method for False Alarm Probabilities\n",
+    "**Author**: Nicholas Hunt-Walker<br/>\n",
+    "**Date**: 9/14/2015<br/>\n",
+    "**Purpose**: We want to estimate the probability that a given periodogram Z-score is a false positive. Modeled after Monte-Carlo simulations of Gaussian white noise, <a href=\"http://adsabs.harvard.edu/abs/2008MNRAS.385.1279B\">Baluev 2008</a> demonstrated that upper limits to False Alarm Probabilities (FAPs) can be estimated from elements of the data and evaluations from a given periodogram. Here, we reproduce the comparison between FAPs as derived from data and FAPs calculated from Baluev's theoretical model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "from gatspy.periodic import LombScargle\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Set up simulation of Gaussian white noise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Want 100,000 trials\n",
+    "N_trials = 100000\n",
+    "# 1,000 time points, evenly spaced\n",
+    "N_pts = 1000\n",
+    "\n",
+    "# time array\n",
+    "t = np.linspace(0, 100, N_pts)\n",
+    "\n",
+    "# W = max(f) * T\n",
+    "W = [50, 500]\n",
+    "scores = np.zeros((N_trials, len(W)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the simulation\n",
+    "\\*\\*Note: Don't actually run this. It'll take forever. Run smaller instances in terminals and restitch the data later\\*\\*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "for ii in range(N_trials):\n",
+    "\n",
+    "    for jj in range(len(W)):\n",
+    "        # maximum frequency/min period\n",
+    "        fmax = W[jj]/t.max()\n",
+    "        \n",
+    "        # \"data\" array\n",
+    "        y = np.random.normal(0, 1.0, t.size)\n",
+    "\n",
+    "        ls = LombScargle().fit(t, y, 1.0)\n",
+    "        ls.optimizer.quiet = True\n",
+    "        ls.optimizer.period_range = (1/fmax, t[-1])\n",
+    "\n",
+    "        chisq_0 = np.var(y)\n",
+    "        scores[ii, jj] = ls.score(ls.best_period) * chisq_0 * 0.5 * (N_pts-1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate maximum FAPs from Baluev 2008, Table 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def false_alarm_single(t, z):\n",
+    "    N = t.size\n",
+    "    Nh = N-1\n",
+    "    Nk = N-3\n",
+    "\n",
+    "    p = (1 - 2*z/Nh)**(0.5*Nk)\n",
+    "    return p\n",
+    "\n",
+    "def false_alarm_max(t, W, z):\n",
+    "    N = t.size\n",
+    "    Nh = N-1\n",
+    "    Nk = N-3\n",
+    "\n",
+    "    fmax = W/t.max()\n",
+    "\n",
+    "    tau = W * (1-2*z/Nh) ** (0.5*(Nk-1)) * np.sqrt(z)\n",
+    "    Psingle = 1 - false_alarm_single(t, z)\n",
+    "    Pmax = Psingle * np.exp(-tau)\n",
+    "\n",
+    "    return 1 - Pmax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "scores = np.linspace(0, 20, 1000)\n",
+    "faps_50 = false_alarm_max(t, W[0], scores)\n",
+    "faps_500 = false_alarm_max(t, W[1], scores)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load results of the simulations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = np.loadtxt(\"all_gaussian.dat\", delimiter=\",\").T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "## Freeman-Diaconis bin-width for histograms\n",
+    "qw1 = np.percentile(data[0], [75,25])\n",
+    "qw1 = qw1[0] - qw1[1]\n",
+    "bw1 = 2*qw1 / (N_trials)**(1./3)\n",
+    "\n",
+    "qw2 = np.percentile(data[1], [75,25])\n",
+    "qw2 = qw2[0] - qw2[1]\n",
+    "bw2 = 2*qw2 / (N_trials)**(1./3)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "H1, bins1 = np.histogram(data[0], bins=np.arange(0, max(data[0]) + bw1, bw1))\n",
+    "H2, bins2 = np.histogram(data[1], bins=np.arange(0, max(data[1]) + bw2, bw2))\n",
+    "H1 = np.cumsum(H1)\n",
+    "H2 = np.cumsum(H2)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfoAAAEaCAYAAAD5UZXLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XlcVOX+wPHPl0VQQBlKTdGysqzUsmwRNcXUrmVpi5V6\n1TQzsyzb7i27mVbavt17+2WZaVmm3dIsM5dUQCvLJLessEVNgUhlAAVcgOf3xww0KiADM5w5w/f9\nevlyzpk553zPPDM88+xijEEppZRSwSnE6gCUUkop5T+a0SullFJBTDN6pZRSKohpRq+UUkoFMc3o\nlVJKqSCmGb1SSikVxDSjV0oppYKYZvRKKeVjItJdRKaKyHVWx6JUmNUBKKVUMDLGjLE6BqVAS/RK\nKeUPW0TkDBG51epAlNKMXtUaEblXRPaLSDP3dhcRSRWRIV6cI0REXjxq3wQR6SciD3u7z+O5RiIy\n5qh9X3pzf9VV3rWDgYjstzoGb4jIJBG5vwqvq8pn8ApgO3CqiET5Plqlqk4zelWbvgNeAQYCGGO+\nBJ4xxrxblYNFxAHcA3T32NcLEGPMJ0C4iFxa1X1Hnd4B3OG5wxjTpVp36b1jrh0k7LaQxnHjrepn\nENdn/XxghzEmvyoXF7dqRa5UJTSjV7WpCfBvYBCAiMQAeVU92BjjNMa8eNQxnXH9UQVYD1zm3re+\nCvs8PQ2cLiLrReQZd3z73f+3EpGfRGSmiKSJyGwRuVxEvhSRrSJykft1Q0TkG/c5XhORY75fIhIl\nIotEZIOIbBaRG4Gnyrn2MefyiONdEflBRD4QkfoVnLNSFZz/aRG5w+M1ZSXcSuL5UUSmicj3IrJU\nRCKPus5jIjLOY3uKiNxdhfflhoru1/36j0Rknfu6ozzOM0xENrrPM6uy+3Xv/5c7TVcDbY73vlX1\nM2iM2WKMWWuMmXacdGjlvv7bwGbgUhHZ7PH8AyIyUUROqei9rk76q7pFM3pVm8QYkwnkishZwAVA\nag3P2QQocD/eD5zk3pdfyb589z5PDwK/GmPON8Y86N7nWcI7HXgeOAtXhnCTu8T/APCw+35uBDob\nY84HSoC/lxNvHyDdGNPBGNMeWAI85HltETm7knOdCfyfMeYcXJnNHcDfyjlnhSo5/1z3/lI3AHOP\nE09r4BVjTDsgB7j+qMvNAIa5rxsC3AS8U4X3ZWkl9wtwizHmQuAi4G4RcYhIW+BfQA9jTAdgXGX3\nKyId3fGcB1zpPld1aiE8P4PlfbaOp7X7HtsBvx/1nPGIqaL3urzPlFJltNe9ssJsXBnFZmNMCoCI\nnAP0ruD1bxtjcip4LgQodj8OdT+u6j5Px6sy3WaM2eKOdQuw3L3/e6AV0BPoCKxz177WB/4o5zyb\ngOdF5GngU2PMFyISd9RrKjrXKmCnMWaN+3XvAncDnwAveJ7zOPdS7vmNMe+ISBNx9aFoAjiNMeki\ncm0l8WwzxmxynzfV/V6UMcbsEJG9ItIBVwb4nTHG6cX7Ut79vgCME5Fr3Ptb4PpBcDHwP2NMtvva\npdc5+n4j3fHHAfONMQeAAyLyCcf/HJTneJ+t49lhjFlbyfOlMVX0Xh/z3nl5fRXkNKNXtUJETgIy\n3JvzgK9xZZIAGGN+AH6oxqmzgNLOTg2B3e7HVd1XVQc9HpcAhzweh+H6Y/y2MeaYjn6ejDE/i8j5\nQF9gsoisAGaV89JjziUirTiyxCmuU5qfReQCXKXSySKywhjzxHHup6JYPwAG4MqU51YhHs/3pRjX\nj4CjTQdGAE1xlfARkTuBW933c2Ul78sx9ysi3XFl3p2MMQdEJAlX5m2oOKMuL/5xR72+uu3jFX0G\nq8qzDb+II2taPd/Pct/r8t67KqS/qkO06l7Vlotwt2MaY/bhyuQblz4pIueIyLgK/jkqOe8XwLnu\nxxcDa6qw7yL3Pk/7gJhq3x2sAAaISGP3/cSJyMlHv8hdWj5gjJmNqyng/HKuXdm5ThaRTu7Hg4HV\n7nMWepzzAo/rrXA/X9VY38fVh2IArky/yvdWiY9wVS9fiLtK3hjzf+6miguMMX9U8L6Ue79AI1y1\nDQfcTSadcGXyK4EbSmtIPGpKKop/FXCNiESKq7/IVe7zVPS+VeR4ny1vZAFN3DFGeMZUkXLeuwsq\ne72qe7REr/xORC4DJgERwIfu3e8Ce0tfU5USvbiGKd0GnC0i9wBv4PrjfqWIDHCdxiwTV/3scfd5\nntsYs1dcnes2A5+52+k9/8Ae/cf2iOeMMT+KyCPAMndb9GFc7clHt7m2B54TkRL3a243xmQffe0K\nzvUnkAbcKSIzgC3AVKCbxzkPAWPc71cIrr4F2Ufda4WxGmN+EJFoYJcxJus4r//zeO+L+/jDIrIS\nV+ZcUabl+b6U3oNUcL8lwO0i8oP7+TXu6/wgIlOAFBEpxvXD8paK4jfGrBWR94GN7ntZW9n75n6u\nSp/BCu6xImXvifu9etwdSzpHficqeq/Le++UKiMVf++UUoHEXVW+0N3hqiqvbwuMMMY84M+4qhBH\nCK425QHGmF+9OK4VXtyvrwTK+6aUr2jVvVL2UuVf5u4hXlZn8ucAPwPLvcnkPdR6SSQQ3jelfElL\n9EoppVQQ0xK9UkopFcQ0o1dKKaWCmGb0SimlVBAL2OF17mEsr+KaJCLZGPOexSEppZRSthPIJfrr\ncE1neRvQz+pglFJKKTuq1YxeRGaISJZ4rM7k3t9HXKtU/SwipQuKxAM73Y+9nTtaKaWUUtR+iX4m\nrqkwy4hIKK41yvsA5wCDxLXa1C6gpftlgVzzoJRSSgWsWs1AjTGrgaNXrroY+MUYs90YcxjXQhr9\ngfnA9SLyKq7VuZRSSinlpUDojOdZRQ+ukvwlxpgC4JbKDhQRne1HKaVUnWOMqfJqi4FQJV6jzNoY\n45d/EydODPjzlpSUkJ+fT2Fh4THndTgMrkXDxuJaiOxioHQRuHdwOI493/z583nzzTfZtm1bQL4X\nOTk55OXllW2vjonhB/cHyAAPAR8DEwHjcDB48GBmzpxZ9vrXX3+dFStWBEz62fm8doxZ3wt9L4Ll\nvfBWIJTo0/mrLR73411VPXjSpEkkJiaSmJjo06B8fT5/nFdEaNCgQbnnzc4GuMb97y979+4lIiKC\nk08Gcf8edDhcr3/55ZdZtWoVAKeeeip9+/bluuuu49JLL/VZzDXRqFGjI7a75uUdsf2U+/+Gyclw\n3XVc9d57JLz3HowYAcCboaE8s3x52eunTZtG9+7dadOmTZVjsMPnojbO6092fC/sGLO/2O29sNPn\nIjk5meTkZK+Pq/W57o9ekUpEwnAtNdkTyMC1POMgY8yPVTiXqe34g1FcHDidAK8DSxBJxpicsue/\n+eYbLr74Yp9fd/jw4bz11ls+P29FFsfE0GP/fiKB4thYmoWHs3btWlq1agXA+vXrOffccwkNDa21\nmOysttNP+Y6mnb2JCMaLqvtaLdGLyBygO3CCiOwEHjXGzBSRscBSIBR4syqZvPKd7LJVt0cDo3E4\nisnJWQcsICzsay688EK/XLdDhw5+OW9Frti3r+zxIYeDZ3fvptWpp4LDwd6ff6ZHjx7s2LHjmJoD\nVb7aTj/lHZHK84G33367liJRvlCTQq2tV68TETNx4kS/VN0rl79K+39V8QNkZmZy++23M27cOHr0\n6HHcPyoBLS6OdU4nHwDPuG/yt99+4+WXX+Y///mP1dEpVS3uUp/VYSgfKE3L0qr7xx57zKsSve0z\nejvHbzelmb7DAXfeOYHJkycDcO6553LfffcxaNAg6tWrZ3GUNeS+yfsiIgi7+26effZZAA4fPkx4\neLjFwSlVdZrRB4+j09LbqnvN6JXXXHnhbuB1RF7BmCwATj75ZKZPn07v3r2rdJ7k5OSArYnZ3qgR\n9fPyaOou4Y8cOZKuXbsywt2xTwV2+inN6INJTTP6QBheVyOTJk2qVi9EVX3Z2WBMY4x5hEaNdgBv\nERLSlp07d9KsWTOrw/OJVrm5NHV/sfaLkDRjBv3vvbfs+b1791oVmlIBqW/fviQmJlJSUmJ1KEEr\nOTmZSZMmeX2cluiVTzgcJeTkfI3D0dmjc1/wOHz4MOFNmwKQtmYNPXr04LfffiMyMtLiyJQqX22W\n6DMyMrj//vuZM2dOlY9ZtGgRmzZtQkRITU3lpptuYtOmTTz++OMVHpOSksKjjz5Kly5dmDhxItu2\nbSMlJYX8/HxGjhwZtB1p63yJXgUGpzMEYzoDrqp9T7t27WL9+vUWROU74eHhZT0Rk846iwdycsoy\n+by8PIqLdd0lVXf985//JCkpidtuu63Kx0RFRTF+/HgaNmzIzTffzIABA7jiiiuOe9zKlSt58skn\niYiIYOrUqQwePJhevXrpcMFKBMKEOSqIZGe7MnqRv3rpP/TQQ7z33nsMHz6cZ555hsaNGwM2bePN\nzuZ2OOImR/XuzaWXXsrYsWOtjq5W2TL9lF9MmTIFEWHatGlVPqb0s7NmzRoGDhwIQEJCAlu2bOH7\n778/4rXNmjWjW7duACxZsoT09HQGDhxIRkYGMTExNGnShLS0NN/cTBCyfUbvr5nxVPWVVt278kJD\nREQzwsLCmDlzJgsWLODZZ5/lllsqXcYg8Llvck9sLH/Mn89Ij9KE9tBXdU1Nmgj27t1LnEc1YNu2\nbWnbtm25r+3cuTPh4eGsW7eOOXPmlA3rLSkpqRMTXVV3ZjzbV92XZvQq8Lg67QkNGjxH/fo/cPnl\nl+N0Ohk1ahSXXXYZXbt2tTrEGjsxJ4eUmBjqN2gAcXF8++23JCQk1IkOSfq9sycR7/75U2ZmJs2b\nNz9i3+bNm5k9e/YR/5KSkgB44YUX2Lt3L1lZWURGRhIfH09BQQHp6ellM1wGs8TExGp1xrN9iV4F\nPld1fmuWLVtCVNT7REffQ8eOHQkLC5KPn0cVxqsXX8x9UVGEhNj+N7QKUv7on1dasl62bBkZGRnk\n5ubSqVMnsrKyaNGiBU6nk+3bt5OQkMDy5cuJiooiISGBGTNmUFRUxK+//srpp58OQPv27Wnfvn25\n1xkwYADffPMNW7duZcyYMXTq1InZs2eze/duRo0a5fsbCxLa617VKtcY/BxiY8P46KN1QVcqLCoq\nIrRxY1ev2L17GTt2LPfffz+nnXaa1aH5nLbRBzYrxtEnJSXRokULVq5cSdeuXfn999/ZsmULgwcP\n5rvvvqNv375Mnz6dkSNH6o9hL9T5Xvc6jt5eXNX5sYhEc/XVxz5v9yrvsLAwxD1n8IchIXz1+uu0\naNHC4qiUqh3p6emcccYZREREkJaWRlRUFPHx8aSkpFBYWMjbb7/Nvn372LRpk9Wh2pKOo1e24zml\nbna260P8wAMPMGvWLM455xyrw6uxQ4cO8WeTJrQICYHsbDZs2ECjRo049dRTrQ5N1QE6M17wqPMl\nemVfrtK967EI9O79BKmpqXTs2JHXX3/d9n+k6tWrR4sc13K/uSJc17EjGzZssDgqpVRdoxm9skxp\nk0tphh8dvYB69UZw4MABbr/9dgYMGEB2MEyzl51NSXY240tKuPbaawHXcKSDBw9aHFjNaJOZUvag\nGb0KGE5nDFFRM4D3gBjmz5/P5ZdfbvuSPYDD4WCUw+GquoiL4//+7/+49dZbrQ5LKVUH2L6NXtej\nD04iv9Gp09+ZMGECV155pdXh+NRhh4PEffuYlZZWNqRIKV/TNvrgoevR2zh+VTFXR70SHI6QoFwk\nxzgcSE4OOBzkbtvGm2++yb333ls2HlmpmtKMPnhoZzxlW5W18bra7V0fz6MXyQkG4nSW9UQcGRvL\nrw8/bLtMXtvolbIHzehVQCstzbubtgF48cUXee2114KjtJKdzf1ffcWLHh3zCgoKLAxIKRVstOpe\n2YYIpKVt5eyzz6akpIRhw4YxdepUGjRoYHVoNef+FbN2yRIGDx7M999/r2vdqxrRqvvgoVX3qs5w\nOKBNmzOJjJxFgwYNmDVrFl26dGHHjh1Wh1Zz7qqLOZdcwgt//KGZvLKVHTt2lC08k5yczIQJE/x+\nnY0bNzJjxowqHVdRTH379iUxMdH2M3Iej2b0yjLetvGWjrePiPg7YWHf0Lp1azZs2MBFF13E2rVr\n/RNkbcrO5iVj6F+vHsTFYYxh2rRpHDhwwOrIyqVt9KrUtm3bWLlyJYDP+pqUVxvheZ3zzjuvystd\nlxdTRkYGDRs2JDk52at59xctWsRTTz3F008/zQ033MCHH37Io48+WukxKSkpdO/enYcffpiDBw/y\n008/8frrr/Piiy+Sm5tb5WtXl+0zep3rvu7JzobQ0Hb88stawsJ6A3DSSSdZHJUPuUv3L4SEMO2O\nO4K+tKHsb9q0abzzzjv07u36PqamptKvXz+6du1Kfn4+xhjGjBlDz549ueqqq8jJyaGoqIhBgwbR\nvXt3Bg8eTHFxMcnJyfTr14/+/fuzdOnSY47xvE5KSgoTJkzAGMOtt95KYmIiffv2JTMzk8suu4xL\nL72UO++8s8KY//nPf5KUlMRtt93m1b1GRUUxfvx4GjZsyM0338yAAQO44oorjnvcypUrefLJJ4mI\niGDq1KkMHjyYXr168dZbb1X52tWd697264RW56ZVYKjJ3AeuvNCByGd8+eU2Tj75ZF+FFRiys7l8\n0yYGnndeWR8EY0xA9czXuSvsqaLPUE3a80ePHs3pp5/OE088QXJyMvXq1WPBggU8+eSTrFixAhHh\nlFNOYerUqSxZsoTXXnuN1q1b065dO+bMmcOUKVOYN28eTZs25fDhwyxevJiFCxeWHbN48WJee+21\nI66TkpICwMcff0zTpk2ZPn06xhiKior4/PPPCQ0NZejQofzyyy/lxjxlyhREhGnTpnl1r6Wf+zVr\n1jBw4EAAEhIS2LJlC99///0Rr23WrBndunUDYMmSJaSnpzNw4EAyMjKIiYmhSZMmpKWleXXtxMRE\nHnvsMa9itn1Gr+o2hyOMM888o2xhnGBy7rnnujomiLC3USOuOPNMPvroI+Lj460OTakKiQjt2rUD\nID4+npycHLKyspg7dy5Lly6lqKiIzp078+uvv3L++ecDcOGFF5KamkrTpk254IILAPjxxx+POaY8\nW7duLXtORNizZw9jxowhNzeX7du3k5GRUe5xNe2ouHfvXuI8xv62bduWtm3blvvazp07Ex4ezrp1\n65gzZ07Zj62SkhJCQ0NrFEdV2L7qXtmXL5pcPBfG8Rxvb4xh165dNT6/5dw3+OrBgyRu2hRQmbw2\nmdmTMabcfzURHh5OcXFx2fk9aw2MMbRp04Zhw4aRlJTE6tWrmTJlCqeffjqpqakAfPvtt7Ru3Rqg\nrL38rLPOOuYYz+uUatOmDV9//TXgyjjnzJnDtddeS1JSEl26dPHLyIPMzEyaN29+xL7Nmzcze/bs\nI/6Vdhx84YUX2Lt3L1lZWURGRhIfH09BQQHp6em0atXK5/EdTUv0KihkZ7syehFXIfiee57gpZde\nYv78+fTo0cPq8GrsX/n5cMIJZTe4YeVKzjvvvICqyld1V7t27Rg/fjwDBw5kzJgxR3wuRYR+/fpx\n991307NnTwDuvfderrnmGj788EO6d+9O8+bNeeihh/jyyy/Lji3vmG7duh1znX79+rFw4UK6d+9O\nTEwMkydPZtiwYSxYsKDS74eIlD2/bNkyMjIyyM3NpVOnTmRlZdGiRQucTifbt28nISGB5cuXExUV\nRUJCAjNmzKCoqIhff/21bBrr9u3b0759+3KvNWDAAL755hu2bt3KmDFj6NSpE7Nnz2b37t2MGjWq\n5glwHDqOXgUdkRKuvXYAH330EWFhYbzxxhsMHz7c6rB8JkmEmxo3Zt26dcHXN0H5jI6jr7qkpCRa\ntGjBypUr6dq1K7///jtbtmxh8ODBfPfdd/Tt25fp06czcuRIr3ro+4qOo1fqKA5HCB999AEREfdT\nVFTEiBEjeOSRR4Km9/qB6GjeLyzUTF4pH0lPT+eMM84gIiKCtLQ0oqKiiI+PJyUlhcLCQt5++232\n7dvHpk2brA61WrREryyTnJzs157broVxpgJjgRIeffRRr3urBizXzVESG8u/br+du+++m2bNmtVq\nCP5OP1UzWqIPHlqiV6oCrn5sY4BPOeeccxg9erTVIfmOu5Peyzk5fPHFF8TGxlodkVIqQGmJXgW9\nuDgwphin0//DWGqbMzYWcnNxuMcXFhcX18pwHRX4tEQfPOp8iV5nxlPHk50NIqFHrIAXLBw5OTjc\nfwAyYmM577zzSE9PtzgqpZQ/VHdmPC3RK8tY0cbrbtrG4YA9e0pYv349HTt2rNUY/GWyCKFPPsn4\n8eNr5XraRh/YtEQfPOp8iV4pb5ROsON0Gu6//34uueQSr+aaDmT/io3loYcfLqu22Lx5s8URKaUC\ngZboVZ3kcBgOHPgXBw48BcDkyZN5+OGHg2MCmrg4PnE6GS3CpqwsGjdubHVEygJaog8eWqJXqhqc\nTqF+/SeB/wLCI488wp133nnM9Jq2lJ1N4dy5fGKMZvJKKc3olXWs7kTpqsYfC/yvbOnIYFkN8aab\nbuIihwPi4igqKuL555/3+br2VqefCix9+/YlMTExaCamCiY6172q8xyOATidTQgNfZBx48ZZHY7v\nuBcAuC88nLSwMO666y6rI1JBKiMjg4YNG7Jo0aIqH7No0SI2bdqEiJCamspNN93Epk2bePzxxys8\nJiUlhUcffZQuXbowceJEtm3bRkpKCvn5+YwcOZLMzMwjths1auSL27M9baNXys3hcK26FWzL3f70\n00+0TEggSiT41vJVFarNNvohQ4awfPly+vXrV+X13UtHbbz66qucfPLJXHXVVaxZs4aEhIQKj0lJ\nSaFr165lc0WMGzeOyZMns23bNlauXMm2bdvKtpOSkoLmh3tN2+i1RK+Um9MpBENfvKOdddZZrjGF\nImzfvp277rqLefPmUa9ePatDU0FiypQpiEiVM3mgbGjmmjVrGDhwIAAJCQls2bKF77///ojXNmvW\njG7dugGwZMkS0tPTGThwIBkZGcTExNC0aVPS0tLYs2cPMTExNGnShLS0NN/cXBDQjF5ZJhDHYTsc\nfy11m50NRUVFbN++vWytbFtzOBh76qlcUb++TzL5QEw/VQXe/pqtQq1ATWoO9u7dS5zHTFZt27al\nbdu25b62c+fOhIeHs27dOubMmVM2SqakpISwsLAjtnWGyL9oRq+Uh9Kabdfa9oZ69UZTv/48Fi1a\nRJcuXawNrqays/mgsJD68fFlv2b2//470dHRVkemalMANXdmZmbSvHnzI/Zt3rz5mFXimjdvTo8e\nPXjhhRcYNWoUWVlZREZGEh8fT0FBAbt27aJVq1aEhYVRUFBAeno6rVq1qsU7CWwB20YvIqcC/wIa\nGWNuqOA12kav/ObQoUNERAwC5lO/fn3mz59Pnz59rA7LZ94V4eWOHfn222+DY/4AdYTabKPfsWMH\njzzyCEOHDiUjI4Pc3Fw6depEVlYWLVq0wOl0sn37dhISEli+fDlRUVEkJCQwY8YM9uzZw4QJEzj9\n9NOPe51ffvmFrVu3kpaWxpgxY9ixYwerVq1i9+7djBo1iuzs7CO2g2V4aU3b6AM2oy8lIh9oRq+s\n4nAUUVAwmkOHZhAWFsY777xT1p5oZ8YYhkVG8lBkJG1zc60OR/mBFRPmJCUl0aJFC1auXEnXrl35\n/fff2bJlC4MHD+a7776jb9++TJ8+nZEjRxISoqO7qyrgJ8wRkRkikiUim4/a30dEfhKRn0XkQX/H\noQKPHcZhO51hNGgwHXiAoqIiBg8ezIIFC6wOq8ZEhHcOHqRtXh7gqr347rvvvDqHHdJP1a709HTO\nOOMMIiIiSEtLIyoqivj4eFJSUigsLOTtt99m3759x1TNK/+qjTb6mbimH5tVukNEQoFXgF5AOvCt\niHwCXAhcADxnjMmohdiUOi6nUzDmWUJCTuD88z+gR48eVofkOw4HRSIMDg8n7LrrmDt3rtURKRsb\nMmQIAMOHD7c2EHWEWqm6F5FWwEJjTHv3dgIw0RjTx739EIAx5mmPY+KAJ4GewHRjzDPlnFer7lWt\nca18dxCHIyKohqOXlJQwNTqaWwsLiSgdbqBsT+e6Dx52HUcfD+z02N4FXOL5AmNMNnD78U40fPjw\nst6VsbGxdOjQoWzIT2nVom7rti+25893bffoERjx+HL7zoIC13aPHjRLS+PHH38kNjY2YOLTbe+3\nVXAprSWpzmgCq0r01wN9jDGj3NtDgEuMMV7N0aklentLtuk47NIhv6UF38OHDwMQHh5uUUS+szc2\nlg55eTz+5puMGDGi0tfaNf3qCi3RB4+A74xXgXSgpcd2S1yleq9NmjSp7JesUrWhNIN3DUUvZsiQ\nIQwYMMDni8ZYIc7pZH50NCNuueWvXzRKqYCQnJxcrYW3rCrRhwFpuNrfM4C1wCBjzI9enldL9MpS\nIj/jcFyC0+mkd+/eLFiwgAYNGlgdlm+I8Ma0aYSHh2vnKhvSEn3wCPgSvYjMAb4CzhSRnSIywhhT\nBIwFlgI/AO97m8krFQgcjjNwOpMRacLnn39Onz59yHMPWbO7Hxs25PHRo+natavVoSilasDvGb0x\nZpAxprkxJsIY09IYM9O9f7Expo0xprUx5qnqnl+r7u0rGNLNtab9ucTErEIkntWrV9OzZ0+yg6Dn\n+tm5uXzfqBGtzzijbF17T8GQfkrZSXWr7m0/NdGkSZO0Q5CyXG5uG4xZzamnnkpERAQRERFWh+QT\njZxOMIZDTif9+/fnww8/tDokFYB27NhBUlIS4MqMJkyY4PfrbNy4kRkzZlTpuIpi6tu3L4mJiZSU\nlPg0Tn9JTEysVkavi9ooywTbDzSH41S2bfsCpzOKqKgoq8PxqS+jo2nw2Wf0/+orGDAACL70U9VX\nuh58jx49fLZugjHmmHN5Xue8887jvPPOq9K5yospIyODhg0bsmjRIq/iWrRoEZs2bUJESE1N5aab\nbmLTpk08/vjjFR6TkpLCo48+SpcuXZg4cSLbtm0jJSWF/Px8Ro4cSWZm5hHbjRo18iqm4wmKEr1W\nIapA4KqjP8X/AAAgAElEQVTGb05Ojm+/pIGgx759/K+khHARiIsjMzNTO3qpMtOmTeOdd96hd+/e\nAKSmptKvXz+6du1Kfn4+xhjGjBlDz549ueqqq8jJyaGoqIhBgwbRvXt3Bg8eTHFxMcnJyfTr14/+\n/fuzdOnSY47xvE5KSgoTJkzAGMOtt95KYmIiffv2JTMzk8suu4xLL72UO++8s8KY//nPf5KUlMRt\nt93m1b1GRUUxfvx4GjZsyM0338yAAQO44oorjnvcypUrefLJJ4mIiGDq1KkMHjyYXr16MXPmzCO2\n33rrrQrPoVX3ynaC9Qda6Zr2wTY6TUQgO5sfnE46duzItGnTrA5JVcPRpdvjbVfF6NGjGTp0KJ9/\n/jnGGOrVq8cnn3zClVdeyYoVK/j000855ZRTWLFiBWPHjuW1115jwYIFtGvXjpSUFNq2bcu8efMQ\nEQ4fPszHH3/M4cOHy4658847ee211464TqmPP/6Ypk2bkpyczKeffsqJJ57I559/zurVq8nLy+OX\nX34pN+YpU6bQu3dvrz/HpfnNmjVr6Ny5MwAJCQls2bKF999//4h/q1atKjtuyZIlTJs2jby8PDIy\nMoiJiaFp06akpaWVbTdp0oS0tLRKr61V90oFAM817ePiICvrMLfddhvjxo2jQ4cO1gbnA9ujo3km\nM5OWDzwAo0dbHY4KMCJCu3btAIiPjycnJ4esrCzmzp3L0qVLKSoqonPnzvz666+cf/75AFx44YWk\npqbStGlTLrjgAgB+/PHHY44pz9atW8ueExH27NnDmDFjyM3NZfv27WRklL9sSk1rpPbu3Uucx6/5\ntm3b0rZt23Jf27lzZ8LDw1m3bh1z5swp+zFVUlJCWFjYEduhoaE1iqs8mtErywR7TUx2tqtk/9JL\nL/HWW2+xYMECli1bxkUXXWR1aDVy5b59rgfuP04pKSl069ZN17S3iaMzuONtV0V4eDjFxcVlx3t+\nFowxtGnThmHDhnHfffcBUFRUxIIFC0hNTeXKK6/k22+/5cwzzwQoW772rLPOOuaYtWvXll2nVJs2\nbfj666/p27cvJSUlzJkzh2uvvZabb76ZIUOG+KWJKTMzk+bNmx+xb/Pmzcesyte8eXN69OjBCy+8\nwKhRo8jKyiIyMpL4+HgKCgrYtWsXrVq1IiwsjIKCAtLT06s1xe3x2D6jL626D/ZMQ9mTwwEPPjiO\n8PA15OQsoFevXixZsoSEhASrQ6s5h4OpUVE807gx3377LY0bN7Y6ImWRdu3aMX78eAYOHMiYMWOO\nyOhFhH79+nH33XfTs2dPAO69916uueYaPvzwQ7p3707z5s156KGH+PLLL8uOLe+Ybt26HXOdfv36\nsXDhQrp3705MTAyTJ09m2LBhLFiwoNIfnyJS9vyyZcvIyMggNzeXTp06kZWVRYsWLXA6nWzfvp2E\nhASWL19OVFQUCQkJzJgxg6KiIn799VdOP/10ANq3b0/79u3LvdaAAQP45ptv2Lp1K2PGjKFTp07M\nnj2b3bt3M2rUKLKzs4/YrkhycnK1mjxrZWY8f9GZ8eytLs2V7nAcJidnCPA/oqOjWbRoEd26dbM6\nrBpJTk6m6OqrOX3/fk7VVe8Cjs6MV3VJSUm0aNGClStX0rVrV37//Xe2bNnC4MGD+e677+jbty/T\np09n5MiRZTUOtSngZ8ZTSoHTGc7hw7OBv7N//36ef/55q0PyiV779nGqMeB0UlhYyH//+1/bjElW\nqlR6ejpnnHEGERERpKWlERUVRXx8PCkpKRQWFvL222+zb9++Y6rm7UJL9ErVIoejmIMHX2T37juC\na6x9XBzXOp3UDw/nncJCv3QoUt7REn3wqPMleh1Hr+zE6QwlMvIfREdHBdfwu+xsJq5fz6yoKEK1\nrV4pvwjo1ev8RUv09laX2ujLIwJ2/vhWmH4ibNywgXfffZfnnnuu1uNSLlqiDx51vkSvlF15Tqxz\n4MCBsjm87e5QbCzXd+jARVOnWh2KUgot0StlOZEi+va9hsWLF/POO+8wePBgq0OqsezsbOJatwan\nExwOzN69Os6+lmmJPnjUtESvGb1SFnM4DAcOTOTAgScICQlhxowZ3HzzzVaH5TMvipD1z3/yzDPP\nWB1KnaI/rIJLna6618549qXp5uJ0CvXrPw48QUlJCSNGjGD69OlWh3VcVUm/zMxMZoWGMvb11/0f\nkDqCMabCf0lJSZU+r/8C7x9oZzxlQ3W9M155RJ4FHgTgk08+4eqrr7Y2oEpUNf1KSkoIOfFE11j7\n2FjCd+8mLMz2k3Lamn737E2r7pWysbg4cDpfJixsMfv2fUxkZKTVIflMfn4+V0VHM+j1171eGlQp\n9RfN6JUKAg5HMSKhQTWr7IYNG5jeqRP/rl+fUKfT6nCUsq0610av7Evb6CvmdIYS6Hmht+nXoUMH\nXjlwgFAREOG3Ro2OWYlM1Q797tUtmtErFaA8x9mDa5nOoJCdTeq6dSTk5bF+/Xqro1Eq6GnVvVIB\nztVuX0hYWD8mTuzOI488YnVINbZq1SqcV15J//x81y+aYGqjUMrP6lzVvQ6vU8EuOxuWLFlFUdEK\nJkyYwBNPPGF1SDXWrVs3+u/f75oD2OlkyZIluuqdUsehw+uU7egQH+9ERb1LQcHNQAmTJk1i4sSJ\nlsbjq/R7rkED3jh4kDV//skJJ5xQ88DUcel3z97qXIleqboiP38IMIuQkBAmTZpUrV/2gejixYtJ\njonhhBNPJLiW9FMqMGiJXikbcbXXvwcM5aqrruSjjz4Kqsln9okw89//5q677tIpXJWqgI6jV6oO\niIlJYv/+zjgcEUHTj80YQ6969WgdEsLUwkJCQrTCUanyaNW9sg3tRFl9+/b1wJgIS8fa+zr9RISX\nUlOZeuiQZvJ+pt+9ukW/TUrZmMMRXM3a5557LiHuCQS+btgwKEYYKGU1rbpXyuZc7fYQG5vPc8/N\nYeTIkbZv3963bx9nN2rENGO4UsfZK3UEbaNXqg4yxhAScjmwnPHjxzNlyhTbZ/Z79+51DbcTAfdS\nnXa/J6V8QdvolW1oO6HviAhRUaOBUJ566inGjx+Pv38E+zv9ysbUOxxMql+f//73v369Xl2i3726\nxfYZvc6Mp5TL/v0D+PDD94EwnnnmGR566CG/Z/a1Ycvq1Sw4fJibxo0Lrg4JSnlJZ8ZTSgEQHf0R\n+fk3AkXMmjWLoUOHWh1SjRUVFbnmCxDh4IEDREREWB2SUpbxeRu9iLQFugGtAANsB1YbY7ZUP0zf\n0IxeqfJFRy8gP38usbHv4HSGWx2Oz+TExvK33Fwei46mz759VoejlCV81kYvIkNFZC3wPHAS8Buu\nTL4Z8LyIfCsiQ2oYr6rDtMnFf/bvvwZj5pKT479M3or0++Ldd+l8zz38LSxMq/FrQL97dUtlc2c6\ngJ7GmHJ/NotIQ2C4P4JSSvlG6Zr2wTJC7aqrruKqq66Cl14CEf744w9OOukkq8NSKqBVq41eRCKM\nMQf9EI+3cWjVvVJV4B6hRmFhIZGRkUExTG1VTAwD9u8ntVEjWubkWB2OUrXGl1X3f4jILRU8/bXX\nkSmlLONwgMORR8+ePXnggQeCojf+zy+/zJzly2mZm2t1KEoFtMqG1x0AbhaRD0QktrYCUnWHthPW\nnuxsKCpKZc2adbz44os8+OCDNc7srU6/kSNH0rNnT3A4MA4H3333naXx2InVaadqV2UZvRNIBDYC\n60WkR61EpJTyi337erBgwQdAGM8991ytTKpTK7KzeaiwkFs7duSww2F1NEoFnArb6EVkvTHmfPfj\ni4F3gAXAI8Da0uespG30SnnPc5x9sEyXO2PGDPr3788JJ57o6oygVBDz2Th6z4zevR0N/Bc4FzjR\nGHNKTYOtKc3olaqeefPmMWDATYSH30Bh4buEhoZaHZJvxMWR7XSSGh1Nbx1nr4KUL+e63+C5YYzZ\nb4wZATwFFFYzPq+ISH8RmSYic0Wkd21cU9UebSe0zvXXX89XX63m8OF3qp3JB2L65e/cSc8OHVi+\nf7/VoQS0QEw75T8VZvTuTL28/R8aY87yX0hHXOtjY8xtwO3ATbVxTaXqioSEBByOMESCZ+6ZBg0a\n8OSTT/J0bGzw3JRSNVRZ1f0MYKox5tsKnr8EuL2iHwTlnKsv8Kcxpr3H/j7Ay0AoMN0Y80wFxz8P\nvGuM2XDUfq26V8oHSte0D5aJdQCIiyPJ6aRIq/FVkPFl1f1LwF0islVEFrqr0N9wP94KjAFeqOJ1\nZgJ9jgo0FHjFvf8cYJCInO2eevclEWkuLs8Ai4/O5JVSvpOd7erD5nTm8NZbb1kdjk9sWb2aG088\nkXCtxld1XGVV95uNMcOA9sAUYAXwOTAZONcYM9wY831VLmKMWY1ruJ6ni4FfjDHbjTGHgblAf2PM\nO8aYe40xGcBdQE9ggIiM9vbmVGDTdsLAUlxcTGhoH0aMGMHTTz993NcHevqdffbZfPHFFySWzgOs\nVfllAj3tlG9VNtc9ItIBaA1sMca87+NrxwM7PbZ3AZd4vsAY8x/gP5WdZPjw4bRq1QqA2NhYOnTo\nQGJiIvDXh1m3A3N7w4YNARVPXd9evXo1//hHD55+ei3jx49n+/btDBw40Lbpt2rVKgDaZGdjjGFY\nSAhdX3+d0aNHB0R8uq3bVd1OTk4uq2krze+8UVkb/aPAECAV6AQ8ZYyZ5vUV/jpfK2BhaRu9iFwP\n9DHGjHJvDwEuMcbc5cU5tY1eKR+LinqLgoJbAMPzzz/P/fffb3VINTZr1ixeueUWlkZH49B58ZXN\n+bKNfiDQwRgzCLgQuK2mwR0lHWjpsd0SV6neK5MmTSr75aOUqrn8/OG8+eZ0AB544AGWLFlicUQ1\nN3jwYJZnZ+MICdFqfGVbycnJTJo0yevjvJkw5ztjzAXVDbCcEn0YkIarDT4DWAsMMsb86MU5tURv\nY8nJyWXVVCrwREVNp6DgK2Jj38DpPHasvV3T788//2RQ06a8m5FBs2bNrA7HEnZNO+XibYm+sjb6\n00RkYQXbxhjTz4ug5gDdgRNEZCfwqDFmpoiMBZbiGl73pjeZvFLKv/Lzb8WYkYSE2Ht63KNNmTKF\nLpGRnHTOOa4xhUoFucpK9ImVHGeMMSl+icgLImImTpxIYmKi/jpVyk9Ka7mDZXx9UVERYWFhrip8\nYzh8+DDh4eFWh6XUcSUnJ5OcnMxjjz3mm7nuKzxA5GRgoDHmWW+D9DWtuleqdnhOqJOVFSQZY1wc\nS5xOHg4N5duDB4Nnvn8V9HzZGc/zpE1E5E4R+QJIBppWMz6lymgnSvv4a0KdvVxyySW8/vrrtk8/\ns3cvbw4YwP81aEBoWFid6qBn97RT3qkwoxeRhiIyXESWAmuA04BTjTGnGWMCZryN9rpXqvY0aLCY\n9evXc/vtt/Ppp59aHU6NiAgffPABCXl5YAzG6SQ7WNonVFDyR6/7Qlwz4T1pjPnavW+bMebUGsTp\nU1p1r1Tte+mll7jvvvsAePPNN7nlllssjqjmSkpKuLN+ffKA2QcPWh2OUpXyZdX9eFxV9K+KyEMi\ncnqNo1NK2d69995L/frPA3Drrbcyc+ZMiyOqufz8fLjlFqY2aKDj7FXQqWyu+5eNMZcAN+Aa/rYA\naCYiD4rImbUVoApe2uRiXwUF9wOjMcbwzTffWB1OjcXExDB16lQaOp1gDFlOJ3v27LE6LL/R717d\nUlkb/ckAxphfjTFT3BPdXAQ0AhbXUnzHpW30SlkjOnogsIT333/V6lB8KiMjg+4hIcw75RSrQ1Hq\nCH6dGU9E5hljrq9RhH6gbfRKWS/Y1rL/448/+Pjjjxk9fnxw3ZgKGt620Vc1oz9iOtxAoRm9UoHD\nPf9M0FklwgX79hEdHW11KEoBfhpHr5Q/aJOLvR2dfg6Hq3T/559/8vnnn1sTlI99+umn3CDCbzEx\nQdVBT797dUtlGf25IrJPRPYB7Usfu//l1VaAx6Nt9EoFhuxscDrz6NGjB3379uWzzz6zOqQaa9Om\nDUtSUznXNVuQ1eGoOs7nbfR2oFX3SgUWh8OQk3Mf8DIRERF88sknXH755VaH5RMlDgdvHDrELTk5\nwTEFsLItrbpXSlnG6RRKSl4ExnLw4EH69+/PihUrrA7LJ+4ZOpT3Cgo4qBPqKJvRjF5ZRptc7K2i\n9BMRYmP/A4zmwIEDXH311aSlpdVqbP4wevRoFsfGEh0E7fX63atbKluPXimlqsVVsn+V0NAibr21\nAWeeaf85ttq2bVvWTr8rNpbpIkyMjUW07V4FONu30et69EoFLoejBBCczio3Jwa84uJiOnTowM03\n38wD//hHcI4pVAGp1tajDyTaGU+pwBdsE+oA7Ny5k5YtW/5VhR8sN6ZsQTvjKdvQdkJ7q2r6/bWW\n/V/77P4DvWXLlq4H2dnMczp59tlnrQ3IS/rdq1s0o1dK1QqHwzV7XmxsBpdeeimbNm2yOqQaS09P\n5x4RLn/wQdt30FPBS6vulVK1KjLyLg4efIUTTzyR5ORkVyc3G8vPzycqKgri4jDGaOc85Xdada+U\nCmi5uc8DV7Bnzx569uzJTz/9ZHVINRIVFQVA0Z9/cnNODh999JHFESl1JM3olWW0ndDeqpt+ERER\nxMbOB3qTlZXFZZddxs8//+zT2KywfPly/gwL42/XXRfw1fj63atbbJ/R61z3StmP0xlJfv4CwsJ6\nkJmZybnnvm91SDXWp08fPjt4kAbunoeHDh2yOiQVZHSue6WU7eTn5zN79mxGjx6FF02OAW9bo0b8\nLS+Pzxo2pHVurtXhqCDjs/Xo7UAzeqWCQ7ANR3/xxReJjIzkjjvv1Al1lM9pZzxlG9rkYm++TL/S\nDF4k4Ju3q+S+++7jjjvucI0pjItjz549Vod0BP3u1S2a0SulAoLnxDq7du0iMzPT6pBqLjubd51O\nOnXqpG32yjJada+UCiixsb+Tm9uDkJAIMjKSaNq0qdUh1cjD9esz5MABzgmmOYCVpbTqXilla7/8\n0oD27aMoKfmRXr16BVy1t7eeLCzkHHeBpEiEnxs1sjgiVddoRq8so+2E9uav9DvxxBNZvnw5ISHn\n8P3339OrVy+yg6AkfOiPPxh4/fVMzMuzOhT97tUxmtErpQJOkyZNSE9fQUhIGzZu3EiTJr0pKCiw\nOqwaEREuuugiZsbGBkePQ2Ub2kavlApYGRkZdO/enV9+GUhJyeOIBMlY+7g4fnU6KWnYkDN0nL3y\nUp1ro9eZ8ZQKXs2bNyc1NRWH4wlCQiRoCsK/rVtHYosWrCkq0tK9qjKdGU/ZTnJyMomJiVaHoarJ\nivQTCY75Z/bv309SUhJXX321K6N3Ol1j7mupL4J+9+ytzpXolVJ1h3v+GduLjo52ZfIA2dl8+MEH\n/KHL2yo/0RK9UspWXAXg7dSrN5nc3FeIjIy0OqQa+d///sf999/P8rw82uTl1WrJXtmTznWvlApq\nxhguvvhi1q1bB/QlNnY+Tmc9q8Oqtt27d5OXl8fpp5/u2hEs7RPKb7TqXtmGdqK0N6vST0SYOXMm\nJ5xwArCInJyBHD582JJYfKFx48ZlmfzBgwf5V2QkeQ6HX6+p3726RTN6pZTttGvXjs8//5zY2Fjg\nI+rVG4rDUWR1WDU2btw4frziCiJzcqwORQURrbpXStnW2rVr6dWrF/v27QPmYcx1VodUIxkZGTRu\n3Jjwpk1rvSe+sg9to1dK1SlfffUVX375JU899Q8gePLFn376iZfOO4/XGjRAtEe+8qBt9Mo2tJ3Q\n3gIl/Tp37sw//vEPsrNdheBgUFxczI033kiXN95wzQYo4tNxhYGSdqp2aEavlAoaDofP80RLhIaG\n8uWXXzJs2DBXFUVpzWUw3JyqdQFbdS8iZwHjgBOApcaYN8t5jVbdK6WOIQJ792bjcDiCYn781157\njV27djF58mQdfqeCr41eREKAucaYG8t5TjN6pdQxGjVKIy+vJ5GRoyksnGB1ODWSnp7O5ZdfzsKF\nCznttNP+KtEHS2cE5bWAa6MXkRkikiUim4/a30dEfhKRn0XkwQqOvRpYBMz1d5yq9mk7ob0FcvrN\nnLmFkJBMDhx4lGeffdbqcGokPj6ejRs3ujJ5oHj37hp3RgjktFO+Vxtt9DOBPp47RCQUeMW9/xxg\nkIicLSJDReQlEWkOYIxZaIy5Ari5FuJUSgWJ6667jrfeegsQHnzwQf79739bHVKNhIWFAVBYWMhV\nV13FvKgoba9XVVYrVfci0gpYaIxp795OACYaY/q4tx8CMMY87XFMd+A6IBL40Rjzcjnn1ap7pVSF\npk+fzqhRowBo0GAq+fm3WxxRzSxdupTZs2czY8YMV+av7fV1krdV92H+DKYS8cBOj+1dwCWeLzDG\npAApxzvR8OHDadWqFQCxsbF06NChbPnF0uop3dZt3a6b261bt+aVV15h7NixFBSsJ9ljedZAiM/b\n7YiICGbNmlW2XQBcCQETn277Zzs5OdldQ0VZfucNq0r01wN9jDGj3NtDgEuMMXd5eV4t0duY5x9d\nZT92Sr/169fTs+f5QTXZ3IYNG7jqggv40hhO8fKm7JR26lgB1xmvAulAS4/tlrhK9V6bNGlS2S8f\npZQqz/nnn182HD1YJtVJSUnhpfff55RguilVqeTkZCZNmuT1cVaV6MOANKAnkAGsBQYZY3708rxa\noldKeSUoR6eJsPP332nZsuXxX6tsL+BK9CIyB/gKOFNEdorICGNMETAWWAr8ALzvbSavlFLVUZrB\ni/xETMwya4PxkRfq16dPq1YUFdl/BT/le37P6I0xg4wxzY0xEcaYlsaYme79i40xbYwxrY0xT1X3\n/Fp1b1+abvZm5/TbvDmdJk26s39/P1asWGF1ODVijKFg/HiWlpSUDcM7HjunXV1W3ap72891P2nS\nJO1UopTySvPmzbn++uuBg1x99dWsWrXK6pCqTUSYMGECLdwT/Rc4HPzwww9Wh6X8IDExMXDb6P1F\n2+iVUtVVUlJC/fqjOHRoBhDNV18tIyEhweqwamT//v1cHRNDu7Fj+e9//2t1OMpPAq6N3t+06l4p\nVR0hISEUFEzj73//O7CfK664gj///NPqsGokIiKCGxs04N/vvmt1KMoPArrXvb9oid7edCyvvQVL\n+hUVFdGgwd8JC7uUgoKxVofjG+4Z8zZu3EjDhg059dRTj3g6WNKurqpzJXqllKqJsLAwDh6cS2Tk\n2OCZPt7hYKMIl59/Plu2bLE6GmUxLdErpZSHuDiCYga9vLw8vmvUiET9Gxl06lyJXtvolVK+VDqD\nHoDDYd9MsmHDhiR6bM+cOZNsO/9yUdpGr+xH2wntLdjTb+PGjXTseCvFxR8CpwA2LOW7qyderV+f\n/5x8MitWrCA+Pj7o0y7Y1bkSvVJK+cO//vUviovXcdppl7FrV3pZKd9Wbfju6on+hYWkpKQQHx9v\ndUTKAlqiV0qpcuTk5NCrVy9SU1M588wzSUlJ4aSTTrLnEvAeE/zv27ePyZMn89hjjxEZGWltXKpa\n6lyJXtvolVL+EBsby7Jlyzj33HPZunUrvXr1Yvfu3bgnoLNfyd69wt3QoUPJzc2lXr16FgelvKVt\n9Mp2tJ3Q3upK+u3evZvExER++OEH5syZw8CBAwEb9s53V0Wkp6ezdetWevToYXVEqprqXIleKaX8\nqXHjxixfvpy5c+eWZfKA/da3d1dFxLdvj4grj/j666+59957LQ5M+ZuW6JVSqgZst769uyqiEGgb\nEsIrCxdy5ZVXWh2V8oK3JXrN6JVSqoZs2UEP2O9wEJ2TU9b+YIwpK+2rwFXnqu61M559abrZm6Yf\n/PTTTxw4cMDqMLxWmnbRTicYgzGGSfXr85///MfawFSldD16pZSqRWvXriUhIYEbb7yR2NhD9uuJ\n72HL6tUsPHyYgffcY9+bqAN0PXqllKpFmzdvJjExkezsbAYMGMCcOXNo0iTMXj3xPRQXFxMaGgoi\nFB0+TFhYmNUhqQrUuap7pZSyQvv27Vm2bBkNGzbkww8/ZMSIEezZU2LPGfTAlckDzkaN6BoezqqY\nGIsjUr6iGb2yjLbx2pumH3Ts2JHFixcTFRXFu+++yx133AEcMT9NQKos7Ra/+iqd772XS/fvr72A\nlF9pRq+UUjXQuXNnPv30U6KiokhISCjbb8sZ9IDBgwfz4osvUlovnJeXZ2k8qua0jV4ppXxg9+7d\nNG7c+Jj9dh16R1wcyYcPM6RRIzZt2kSc3X6xBLE610avw+uUUoGgvEwe7FuyJzub1UVFvJOeTlzr\n1lZHo9C57pUN1ZW50oOVpp93Aqlk73XaiWBKSti1axctW7b0W1yqaupciV4ppQLV2rVrmTZtmtVh\n1JiJjeWB+vUZMmQIWriyHy3RK6WUH2RlZXHmmWeSl5fH9OnT+cc/RgL2G18PrjH2j4WFcc/evdpW\nHwC0RK+UUgGgadOmPPbYYwCMGjWKV155D7Bne31oaCiPOxzEnXACxMXhdDrZtm2b1WGpKtKMXllG\nO1Ham6bf8d1zzz1MmTIFYwzDhg3jjTfmBcTSttVKO/e6vLtLSugRF8ecc87xeVzKPzSjV0opP3r4\n4Yd55JFHKC4uZsiQIWRmZtq3Jz4QuXMnd06bxngbLuZTV2kbvVJK+ZkxhoceeoiOHTty4403lu23\n3Vr2ntzDCL766ivOOussbbuvRboevVJK2UhcHPZcCEeEFcuXM2jQID755BM6depkdUR1hnbGU7ah\nbbz2punnG+6m71ptt/dV2p111ll8+umnmskHONtn9DoznlLKzg4fPmx1CNXjcBDfvj0XX3wx4Gqe\nePPNNzl48KDFgQUvnRlPKaVsJiUlhVtuuYWFCxfStes59qvC95jub/z48axcuZKlS5cSGxtrcWDB\nTdvolVLKJq6//nrmz59Ps2bNWLVqFa1btw6oqXKPy6ODwQ9ffEHLli2J0XXs/U7b6JVtaJOLvWn6\n1YdquYsAAAikSURBVNy7775Ljx49yMzM5LLLLmPHjh1lQ+/8OfzOZ2lX2sEAOKdtW2JOOQWAP//8\nk6efflqnyw0QmtErpZRF6tevzyeffELnzp3ZuXMnl112GZs3p2NM7XfQqxGPHoXFxcX87W9/44CO\nsw8YWnWvlFIWy83NpWfPnmzcuJEFCxbQt29fwIZD79ztDr/99hunnXaa1dEELW2jV0opG9q7dy/r\n16+nV69exzxnm4l1yulgsHjxYn799VfGjh1rUVDBR9volW1oG6+9afr51gknnFBuJg+uDN6X1fi1\nlXY7d+5kxIgRdOzYsVaup8oXZnUASimljq+0k57ndqCX8Fu2bMkPP/yg0+NaTKvulVIqgH377be0\na9eO+vXrH7E/IIfhVRJUSUkJd999N/3796d37961HFhw0ap7pZQKEsuXL6dbt25cd911x8w453DY\na/W7+fPns3nzZp0u1wIBndGLSJSIfCsifa2ORfmetvHam6af/8XHxxMTE8OSJUu46aabjpgutybt\n9lak3fXXX8+yZcvKJtTR2tjaE9AZPfBP4H2rg1D+sWHDBqtDUDWg6ed/Z599Np9//jkOh4OPP/6Y\noUOHUlxcXOPz+i3tKpntR0SIiIgAID09nU6dOpGenu6fONQR/J7Ri8gMEckSkc1H7e8jIj+JyM8i\n8mA5x/UGfgB2+ztGZY2cnByrQ1A1oOlXO8477zyWLl1KTEwM77//PmPGjKnxOf2WdqUT5xxntp+X\nXnqJG264gfj4eP/EoY5QGyX6mUAfzx0iEgq84t5/DjBIRM4WkaEi8pKINAe6A52AwcAoEalyxwNf\n8FfVlt3O6+9z+4Md3wu7ndef7Phe+Dvmiy66iM8++4y4uDj69+9f9nxpATqQ2urL3otKOhE899xz\nPPDAA2Xbhw4dqvp5fcyOnwtv+T2jN8asBo7+aXcx8IsxZrsx5jAwF+hvjHnHGHOvMSbDGPOIMeZe\n4D1gWm13r7fbh8qOH9bt27f75bx2fC/sdl6wX/rZ/XPRtWtXtm/fXjZrHlR/LXt/pR14xFxJJwLP\nctu8efPo0qULJSUlVTuvj9nxc+GtWhleJyKtgIXGmPbu7QHA34wxo9zbQ4BLjDF3eXle7c2hlFKq\nzvFmeJ1VE+b4JIP25kaVUkqpusiqXvfpQEuP7ZbALotiUUoppYKWVRn9OuAMEWklIvWAm4BPLIpF\nKaWUClq1MbxuDvAVcKaI7BSREcaYImAssBTXELr3jTE/enneSofnqcAmIttFZJOIrBeRtVbHoypW\n3hBZEYkTkc9FZKuILBORWCtjVBWrIP0micgu9/dvvYj0qewcyhoi0lJEkkRki4h8LyJ3u/d79f2z\n5Vz37uF5aUAvXM0A3wKDvP2xoKwjItuAjsaYAF+WQ4nIpcB+YJZHh9pngT3GmGfdP7QdxpiHrIxT\nla+C9JsI7DPGvGhpcKpSInIScJIxZoOIRAOpwDXACLz4/gX6zHgVKXd4nsUxKe9pZ0obqGCIbD/g\nbffjt3H98VEBqIL0A/3+BTxjzB/GmA3ux/uBH4F4vPz+2TWjjwd2emzvcu9T9mGA5SKyTkRGWR2M\n8lpTY0yW+3EW0NTKYFS13CUiG0XkTW16CXzuYernA9/g5ffPrhm9/dob1NG6GGPOB64A7nRXLyob\nck9mpd9Je5kKnAp0ADKBF6wNR1XGXW0/DxhnjNnn+VxVvn92zeh1eJ7NGWMy3f/v5v/bu7sQq6ow\nDuPPH7MPxQoyMiJJCu+EKIouDINCCPpAihooMBHTm4QuCzGhwIoog6CLkqj0ppusbjOjsKjIKFOM\nYizoA4WuoqCo3i72GjsMx8mxcTxz5vnBwNpr7X32OnPYvGetffZ64XW62zGaOY60+4ckuRg4epr7\no0moqqPVAC/i9TewksylC/KvVtWuVj2p62+mBnofz5vBksxLsqCV5wMrgf0TH6UB8yawupVXA7sm\n2FcDpgWHMavw+htILcfLduBgVW3raZrU9Tcjf3UPkORmYBswB9heVVtPc5d0gpIsoRvFQ7c6404/\nv8HVHpFdASykux+4GXgDeA1YDHwL3FVVprMbQH0+v0eAG+im7Qs4DKzvueerAZFkOfAe8AX/Ts8/\nBHzMJK6/GRvoJUnSf5upU/eSJOkEGOglSRpiBnpJkoaYgV6SpCFmoJckaYgZ6CVJGmIGeklTIslj\nPWlPP2spNP9MMq+135JkSytfmOSjJJ8mWZ5k99giSpKmls/RSzolkuwARqtqc9veA4xU1ZEkI8CN\nVbWuta0DFpg2VZp6juilWaAtF30oyUtJvkqyM8nKJHvbyPuatt+1ST5Isq+1LW31DybZ3srLkuxP\ncvYE57sXuBzY0rYvBc5sQf5K4Ang9jbyPwt4Cxg5lf8DabZyRC/NAi3F5dd0y54eBD4BPq+qtUlu\nA9ZU1ao2ff5bVf2V5CZgQ1Xd2dbcfpdu2emHgY1V9eEE53ofWFFVo61uhC5j4QNtezVwdVVt7Dlu\nFFhWVb9O9fuXZrMzTncHJE2bw1V1ACDJAeDtVv8lcFkrnw+8kuQKurW150KXCjPJfXTJT56fIMjP\nAXYAm8aCfLOYLh3qsV3bX68jdJkoD53Mm5PUn1P30uzxe0/5b+CPnvLYl/5Hgd1VtQy4Feidnl8K\n/AJcMsE5NgE/VNXLfdp6A3u/qcQcp17S/2Cgl9TrXODHVl4zVpnkPOBZ4HrggiR3jD8wyXV0KTPX\n93nd74BFvbv32eci4PuT67ak4zHQS7PH+NFy9Sk/CWxNso8uBfRY/dPAc1X1DbAWeDzJwnGvtwU4\nB9gz7jG7JcBe4Kpx5zt2/iSLgJ+9Py9NPX+MJ2laJHkHuKeqfurTdj8wv6qemf6eScPNEb2k6fIU\nsOE4bXcDL0xjX6RZwxG9JElDzBG9JElDzEAvSdIQM9BLkjTEDPSSJA0xA70kSUPMQC9J0hD7B1ih\nI5YbWRO/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x107ed6f50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = plt.figure(figsize=(8,4))\n",
+    "fig.subplots_adjust(bottom=0.15)\n",
+    "plt.suptitle(\"$N = 1000$ time steps, evenly-spaced, $10^5$ runs\")\n",
+    "\n",
+    "ax = plt.subplot(111)\n",
+    "ax.step(bins1[:-1], 1 - H1/float(max(H1)), color='b', label=\"f$_{max}T = 50$\")\n",
+    "ax.plot(scores, faps_50, color='k', linewidth=2, linestyle='--', label=\"theoretical f$_{max}T=50$\")\n",
+    "ax.step(bins2[:-1], 1 - H2/float(max(H2)), color='r', label=\"f$_{max}T = 500$\")\n",
+    "ax.plot(scores, faps_500, color='k', linewidth=2, linestyle=':', label=\"theoretical f$_{max}T=500$\")\n",
+    "ax.set_xlabel(\"max Z(f)\")\n",
+    "ax.set_ylabel(\"FAP(Z)\")\n",
+    "ax.legend(loc=\"best\", fontsize=8)\n",
+    "ax.set_ylim(1E-4,1)\n",
+    "ax.set_xlim(0, 20)\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.minorticks_on()\n",
+    "ax.grid()\n",
+    "\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/gatspy/periodic/lomb_scargle.py
+++ b/gatspy/periodic/lomb_scargle.py
@@ -5,6 +5,7 @@ __all__ = ['LombScargle', 'LombScargleAstroML']
 import warnings
 
 import numpy as np
+from scipy.special import gamma
 
 from .modeler import PeriodicModeler
 
@@ -203,6 +204,54 @@ class LombScargle(LeastSquaresMixin, PeriodicModeler):
 
     def _score(self, periods):
         return LeastSquaresMixin._score(self, periods)
+
+    def false_alarm_single(self, periods):
+        """
+        Calculate the False Alarm Probability for every period
+        provided by the input param.
+        Following the method outlined in Baluev 2008, Table 1
+        """
+        t = self.t
+        y = self.y
+        dy = self.dy
+        N = t.size
+        Nh = N-1
+        Nk = N-3
+
+        z = self.score(periods) * 0.5 * Nh
+        p = (1 - 2*z/Nh)**(0.5*Nk)
+        return p
+
+    def false_alarm_max(self):
+        """
+        Calculate the False Alarm Probability for the best period.
+        Following the method outlined in Baluev 2008, Table 1 and 
+        eq. 5
+        """
+        t = self.t
+        y = self.y
+        dy = self.dy
+        N = t.size
+        Nh = N-1
+        Nk = N-3
+        best_period = self.best_period
+
+        z = self.score(best_period) * 0.5 * Nh
+        fmax = 1/min(self.optimizer.period_range)
+        gamma_H = np.sqrt(2./Nh) * gamma(0.5*Nh) / gamma(0.5*(Nh-1))
+
+        def avg(phi, dy):
+            return np.sum(phi/dy**2)
+        def bar(phi, dy):
+            return avg(phi, dy) / avg(np.ones(N), dy)
+
+        var_t = bar(t**2, dy) - bar(t, dy)**2
+        W = fmax * np.sqrt(4*np.pi*var_t)
+        tau = gamma_H * W * (1-2*z/Nh) ** (0.5*(Nk-1)) * np.sqrt(z)
+        Psingle = 1 - self.false_alarm_single(best_period)
+        Pmax = Psingle*np.exp(-tau)
+
+        return 1 - Pmax
 
 
 class LombScargleAstroML(LombScargle):

--- a/gatspy/periodic/modeler.py
+++ b/gatspy/periodic/modeler.py
@@ -132,7 +132,7 @@ class PeriodicModeler(object):
         Parameters
         ----------
         periods : float or array_like
-            Array of angular frequencies at which to compute
+            Array of periods at which to compute
             the periodogram.
 
         Returns


### PR DESCRIPTION
Added Baluev 2008 method for calculating false alarm probabilities to lomb_scargle.py. Also added an ipynb for demonstrating the comparison between Baluev 2008 theoretical model and data from Gaussian white noise in the examples directory