### PR TITLE
Describing how to silence optimizer in periodic docstrings

### DIFF
--- a/gatspy/periodic/lomb_scargle.py
+++ b/gatspy/periodic/lomb_scargle.py
@@ -37,8 +37,9 @@ class LombScargle(LeastSquaresMixin, PeriodicModeler):
         If True, multiply regularization by the trace of the matrix
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     Examples
     --------
@@ -148,8 +149,9 @@ class LombScargleAstroML(LombScargle):
         use the faster version of the code from astroML_addons
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     Examples
     --------

--- a/gatspy/periodic/lomb_scargle_fast.py
+++ b/gatspy/periodic/lomb_scargle_fast.py
@@ -353,8 +353,9 @@ class LombScargleFast(LombScargle):
         Dictionary of keywords to pass to the ``lomb_scargle_fast`` routine.
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     Examples
     --------

--- a/gatspy/periodic/lomb_scargle_multiband.py
+++ b/gatspy/periodic/lomb_scargle_multiband.py
@@ -39,6 +39,9 @@ class LombScargleMultiband(LeastSquaresMixin, PeriodicModelerMultiband):
         the normal matrix
     center_data : boolean (default = True)
         if True, then center the y data prior to the fit
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     See Also
     --------
@@ -167,8 +170,9 @@ class LombScargleMultibandFast(PeriodicModelerMultiband):
         :class:`LombScargle` otherwise.
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     See Also
     --------

--- a/gatspy/periodic/naive_multiband.py
+++ b/gatspy/periodic/naive_multiband.py
@@ -36,8 +36,9 @@ class NaiveMultiband(PeriodicModelerMultiband):
         Single-band model to use on data from each band.
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
     *args, **kwargs :
         additional arguments are passed to BaseModel on construction.
     """

--- a/gatspy/periodic/supersmoother.py
+++ b/gatspy/periodic/supersmoother.py
@@ -26,8 +26,9 @@ class SuperSmoother(PeriodicModeler):
         LinearScanOptimizer will be used.
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
 
     Examples
     --------
@@ -93,8 +94,9 @@ class SuperSmootherMultiband(PeriodicModelerMultiband):
         The base model to use for each individual band.
     fit_period : bool (optional)
         If True, then fit for the best period when fit() method is called.
-    optimizer_kwds : dict (optional
-        Dictionary of keyword arguments for constructing the optimizer
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
     """
     def __init__(self, optimizer=None, BaseModel=SuperSmoother,
                  fit_period=False, optimizer_kwds=None):


### PR DESCRIPTION
The current docs for the periodogram classes don't explicitly indicate how to silence the optimizer output, and since the user might never directly interact with the optimizer, it's easy to just assume there's no way to silence the outputs. 

I've put in an example in the docstrings of the periodogram constructors in the `periodic` module which indicates how to set `quiet=True` in the optimizer from the periodogram constructors (simply set `optimizer_kwds={"quiet": True}`).