### PR TITLE
Add fit_trend parameter to LombScargle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Fix bug in ``predict()`` for ``LombScargle`` methods when ``center_data=False``
 - Fix bug in ``score()`` for ``LombScargle`` methods when ``center_data=False`` and ``fit_offset=False``
 - Make ``supersmoother`` a soft dependency
+- New feature: ``gatspy.periodic.TrendedLombScargle`` extends ``LombScargle``
+  by adding a linear trend parameter ``d*t`` to the fitted model
 
 ## (v0.2.1) bugfix release (19 Aug 2015)
 

--- a/doc/periodic/index.rst
+++ b/doc/periodic/index.rst
@@ -17,6 +17,7 @@ All of these fitters are classes which derive from a common
 
    lomb_scargle
    lomb_scargle_multiband
+   trended_lomb_scargle
    supersmoother
    template
    API

--- a/doc/periodic/trended_lomb_scargle.rst
+++ b/doc/periodic/trended_lomb_scargle.rst
@@ -1,0 +1,90 @@
+.. _periodic_trended_lomb_scargle:
+
+Trended Lomb-Scargle Periodogram
+================================
+
+The standard Lomb-Scargle methods in ``gatspy``
+(:class:`~gatspy.periodic.LombScargle`, :class:`~gatspy.periodic.LombScargleFast`,
+and :class:`~gatspy.periodic.LombScargleAstroML`)
+fit a sinusoidal model to the data by minimizing the (weighted) squared
+residuals. These methods also support a floating mean term,
+which is an additional parameter that estimates the mean of the underlying
+model. The :class:`~gatspy.periodic.TrendedLombScargle` class extends
+:class:`~gatspy.periodic.LombScargle` by adding a trend parameter
+that is linear in time. Such a parameter may be appropriate when the underlying
+time series exhibits some non-stationarity.
+
+API of Trended Lomb-Scargle Model
+---------------------------------
+The :class:`~gatspy.periodic.TrendedLombScargle` class has the same API as
+:class:`~gatspy.periodic.LombScargle`; the only difference is the underlying
+model that is fit to the data.
+
+Trended Lomb-Scargle Example
+----------------------------
+In order to motivate the trended Lomb-Scargle model, we'll start with a
+one r-band RR Lyrae lightcurve and examine the effect of adding a linear trend
+on the estimated period. First, we'll estimate the period as in
+:ref:`periodic_lomb_scargle` before we add the trend:
+
+.. ipython::
+
+    In [1]: from gatspy import datasets, periodic
+
+    In [2]: rrlyrae = datasets.fetch_rrlyrae()
+
+    In [3]: lcid = rrlyrae.ids[0]
+
+    In [4]: t, mag, dmag, filts = rrlyrae.get_lightcurve(lcid)
+
+    In [5]: mask = (filts == 'r')
+
+    In [6]: t_r, mag_r, dmag_r = t[mask], mag[mask], dmag[mask]
+
+    In [7]: model = periodic.LombScargleFast(fit_period=True)
+
+    In [8]: model.optimizer.period_range = (0.2, 1.2)
+
+    In [9]: model.fit(t_r, mag_r, dmag_r);
+    
+    In [10]: old_best_period = model.best_period
+
+    In [11]: old_best_period
+
+The estimated period matches the period measured by Sesar 2010 to within
+:math:`10^{-6}` days.
+
+Now we will add a small linear trend to the observed data and see how the
+estimated period is affected:
+
+.. ipython::
+
+    In [12]: slope = 0.005
+
+    In [13]: mag_r += slope * (t_r - t_r[0])
+
+    In [14]: model.fit(t_r, mag_r, dmag_r);
+
+    In [15]: new_best_period = model.best_period
+
+    In [16]: model.score([old_best_period, new_best_period])
+
+The addition of a small linear trend has greatly changed the estimated period;
+in fact, the old best period now has very little power in the estimated
+periodogram. Now let's instead include a trend parameter by using the
+:class:`~gatspy.periodic.TrendedLombScargle` model:
+
+.. ipython::
+
+    In [17]: tmodel = periodic.TrendedLombScargle(fit_period=True)
+
+    In [18]: tmodel.optimizer.period_range = (0.2, 1.2)
+ 
+    In [19]: tmodel.fit(t_r, mag_r, dmag_r);
+
+    In [20]: trended_model_best_period = tmodel.best_period
+
+    In [21]: trended_model_best_period
+
+The new trend parameter accounts for the linear increasing trend in the data,
+and we once again recover the original estimated period.

--- a/gatspy/periodic/__init__.py
+++ b/gatspy/periodic/__init__.py
@@ -6,13 +6,14 @@ from __future__ import absolute_import
 
 __all__ = ['LombScargle', 'LombScargleFast', 'LombScargleAstroML',
            'LombScargleMultiband', 'LombScargleMultibandFast',
-           'SuperSmoother', 'SuperSmootherMultiband',
+           'TrendedLombScargle', 'SuperSmoother', 'SuperSmootherMultiband',
            'RRLyraeTemplateModeler', 'RRLyraeTemplateModelerMultiband',
            'NaiveMultiband']
 
 from .lomb_scargle import *
 from .lomb_scargle_fast import *
 from .lomb_scargle_multiband import *
+from .trended_lomb_scargle import *
 from .supersmoother import *
 from .template_modeler import *
 from .naive_multiband import *

--- a/gatspy/periodic/tests/test_trended_lomb_scargle.py
+++ b/gatspy/periodic/tests/test_trended_lomb_scargle.py
@@ -1,0 +1,32 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_, assert_raises
+from nose import SkipTest
+
+from .. import LombScargle, TrendedLombScargle
+
+
+def _generate_data(N=100, period=1, theta=[10, 2, 3], dy=1, rseed=0):
+    """Generate some data for testing"""
+    rng = np.random.RandomState(rseed)
+    t = 20 * period * rng.rand(N)
+    omega = 2 * np.pi / period
+    y = theta[0] + theta[1] * np.sin(omega * t) + theta[2] * np.cos(omega * t)
+    dy = dy * (0.5 + rng.rand(N))
+    y += dy * rng.randn(N)
+    return t, y, dy
+
+
+def test_lomb_scargle_linear_trend(N=100, period=1, slope=5):
+    """Test whether the generalized lomb-scargle properly fits data with a
+    linear trend component
+    """
+    t, y, dy = _generate_data(N, period)
+    model = LombScargle().fit(t, y, dy)
+    model.optimizer.period_range = (period - 0.5, period + 0.5)
+    y_hat = model.predict(t)
+
+    y_trend = y + slope * t
+    model = TrendedLombScargle().fit(t, y, dy)
+    model.optimizer.period_range = (period - 0.5, period + 0.5)
+    y_hat_trend = model.fit(t, y_trend, dy).predict(t)
+    assert_allclose(y_hat, y_hat_trend - slope * t, rtol=5E-2)

--- a/gatspy/periodic/trended_lomb_scargle.py
+++ b/gatspy/periodic/trended_lomb_scargle.py
@@ -1,0 +1,92 @@
+from __future__ import division, print_function, absolute_import
+
+__all__ = ['TrendedLombScargle']
+
+import warnings
+
+import numpy as np
+
+from .modeler import PeriodicModeler
+from .lomb_scargle import LombScargle
+
+
+class TrendedLombScargle(LombScargle):
+    """Trended Lomb-Scargle Periodogram Implementation
+
+    This is a generalized periodogram implementation using the matrix formalism
+    outlined in VanderPlas & Ivezic 2015. It fits both a floating mean
+    and a trend parameter (as opposed to the `LombScargle` class, which 
+    fits only the mean).
+
+    Parameters
+    ----------
+    optimizer : PeriodicOptimizer instance
+        Optimizer to use to find the best period. If not specified, the
+        LinearScanOptimizer will be used.
+    center_data : boolean (default = True)
+        If True, then compute the weighted mean of the input data and subtract
+        before fitting the model.
+    fit_offset : boolean (default = True)
+        If True, then fit a floating-mean sinusoid model.
+    Nterms : int (default = 1)
+        Number of Fourier frequencies to fit in the model
+    regularization : float, vector or None (default = None)
+        If specified, then add this regularization penalty to the
+        least squares fit.
+    regularize_by_trace : boolean (default = True)
+        If True, multiply regularization by the trace of the matrix
+    fit_period : bool (optional)
+        If True, then fit for the best period when fit() method is called.
+    optimizer_kwds : dict (optional)
+        Dictionary of keyword arguments for constructing the optimizer. For
+        example, silence optimizer output with `optimizer_kwds={"quiet": True}`.
+
+    Examples
+    --------
+    >>> rng = np.random.RandomState(0)
+    >>> t = 100 * rng.rand(100)
+    >>> dy = 0.1
+    >>> omega = 10
+    >>> slope = 2.
+    >>> y = np.sin(omega * t) + slope * t + dy * rng.randn(100)
+    >>> ls = TrendedLombScargle().fit(t, y, dy)
+    >>> ls.optimizer.period_range = (0.2, 1.2)
+    >>> ls.best_period
+    Finding optimal frequency:
+     - Estimated peak width = 0.0639
+     - Using 5 steps per peak; omega_step = 0.0128
+     - User-specified period range:  0.2 to 1.2
+     - Computing periods at 2051 steps
+    Zooming-in on 5 candidate peaks:
+     - Computing periods at 1000 steps
+    0.62827068275990694
+    >>> ls.predict([0, 0.5])
+    array([-0.01144474,  0.07567192])
+
+    See Also
+    --------
+    LombScargle
+    LombScargleAstroML
+    LombScargleMultiband
+    LombScargleMultibandFast
+    """
+
+    def _construct_X(self, omega, weighted=True, **kwargs):
+        """Construct the design matrix for the problem"""
+        t = kwargs.get('t', self.t)
+        dy = kwargs.get('dy', self.dy)
+        fit_offset = kwargs.get('fit_offset', self.fit_offset)
+
+        offsets = []
+        if fit_offset:
+            offsets.append(np.ones(len(t)))
+        offsets.append(t) #  coefficients for trend parameter
+
+        cols = sum(([np.sin((i + 1) * omega * t),
+                     np.cos((i + 1) * omega * t)]
+                    for i in range(self.Nterms)), offsets)
+
+        if weighted:
+            return np.transpose(np.vstack(cols) / dy)
+        else:
+            return np.transpose(np.vstack(cols))


### PR DESCRIPTION
We are looking into incorporating `gatspy`'s LS periodogram into [mltsp](https://github.com/mltsp/mltsp), and one feature that would be nice is the ability to also estimate a linear trend term from a LS model; i.e.,

    y_hat(t) = a*sin(w*t) + b*cos(w*t) + c + d*t

Adding this to the least-squares formulation of LombScargle seems trivial, so I took a stab at it here.

- I don't believe any additional changes to `LombScargle._score` are needed, does that seem right?
- If you think this is useful here, I would also like to add it to `LombScargleFast`; that would just require a bit of algebra, and might also make that code somewhat more complicated (whereas here the additional complexity is minimal).

Let me know what you think!