### PR TITLE
BUG: Fix LinAlgError for badly-conditioned data

### DIFF
--- a/gatspy/periodic/_least_squares_mixin.py
+++ b/gatspy/periodic/_least_squares_mixin.py
@@ -72,7 +72,11 @@ class LeastSquaresMixin(object):
         for i, omega in enumerate(omegas.flat):
             Xw, XTX = self._construct_X_M(omega)
             XTy = np.dot(Xw.T, self.yw_)
-            chi2_0_minus_chi2[i] = np.dot(XTy.T, np.linalg.solve(XTX, XTy))
+            try:
+                chi2_0_minus_chi2[i] = np.dot(XTy.T, np.linalg.solve(XTX, XTy))
+            # If X'X is not invertible, use pseudoinverse instead
+            except np.linalg.LinAlgError:
+                chi2_0_minus_chi2[i] = np.dot(XTy.T, np.linalg.lstsq(XTX, XTy)[0])
 
         # construct and return the power from the chi2 difference
         if self.center_data:

--- a/gatspy/periodic/tests/test_lomb_scargle.py
+++ b/gatspy/periodic/tests/test_lomb_scargle.py
@@ -184,3 +184,15 @@ def test_power_normalization(N=100, period=1):
         for fit_offset in [True, False]:
             for center_data in [True, False]:
                 yield check_model, Model, fit_offset, center_data
+
+
+def test_ill_conditioned():
+    """Test model on data chosen such that X_w' X_w is nearly singular for some
+    possible value of omega"""
+    N = 201
+    omega = 0.1
+    t = np.linspace(0, 2, N)
+    y = np.sin(2 * np.pi * omega * t)
+    dy = np.repeat(0.1, N)
+    opt_args = {'period_range': (0.01, t.max()), 'quiet': True}
+    model = LombScargle(fit_period=True, optimizer_kwds=opt_args).fit(t, y, dy)


### PR DESCRIPTION
Fall back on pseudoinverse when `X_w' X_w` is not invertible during power spectrum computation.

Example:
```
import numpy as np
import gatspy

np.random.seed(0)
n = 201
w = 0.1
t = np.linspace(0, 8 * np.pi, n)
m = np.sin(2 * np.pi * w * t)
e = np.repeat(1e-1, n)
opt_args = {'period_range': (0.01, t.max()), 'quiet': True}
model = gatspy.periodic.LombScargle(fit_period=True, optimizer_kwds=opt_args).fit(t, m, e)
...
LinAlgError: Singular matrix
```

Using `np.linalg.lstsq` seems to be slower (I tried benchmarking it saw 10-20% time increases) so I figured only falling back when there's an error would be better.